### PR TITLE
Correct COCO format

### DIFF
--- a/convert-suite-exports/utils/reader.py
+++ b/convert-suite-exports/utils/reader.py
@@ -97,7 +97,7 @@ def read_labels(labels, project_type, categories, images):
             annotations.append({
                 'id': len(annotations) + 1,
                 'image_id': image_id,
-                'is_crowd': 0,
+                'iscrowd': 0,
                 **anno
             })
     return annotations


### PR DESCRIPTION
Change is_crowd to iscrowd to match COCO format.
COCO format can be found [here](https://cocodataset.org/#format-data).